### PR TITLE
feat: return every referendum in referenda SDK

### DIFF
--- a/packages/sdk-governance/CHANGELOG.md
+++ b/packages/sdk-governance/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - **Bounties**
   - Add bounty and child bounty account.
+- **Conviction Voting**
+  - Add conviction voting SDK
+
+### Changed
+
+- **Referenda**
+  - The SDK now returns all referenda instead of only the ongoing ones.
 
 ### Fixed
 

--- a/packages/sdk-governance/src/referenda/descriptors.ts
+++ b/packages/sdk-governance/src/referenda/descriptors.ts
@@ -12,11 +12,15 @@ import {
   TypedApi,
 } from "polkadot-api"
 
-type WhoAmount = {
+export type WhoAmount = {
   who: SS58String
   amount: bigint
 }
-type BasicReferndumInfo = [number, WhoAmount | undefined, WhoAmount | undefined]
+type BasicReferendumInfo = [
+  number,
+  WhoAmount | undefined,
+  WhoAmount | undefined,
+]
 
 export type PolkadotRuntimeOriginCaller = Enum<{
   system: Enum<{
@@ -89,10 +93,10 @@ export type ReferendumInfo = Enum<{
     in_queue: boolean
     alarm?: [number, FixedSizeArray<2, number>] | undefined
   }
-  Approved: BasicReferndumInfo
-  Rejected: BasicReferndumInfo
-  Cancelled: BasicReferndumInfo
-  TimedOut: BasicReferndumInfo
+  Approved: BasicReferendumInfo
+  Rejected: BasicReferendumInfo
+  Cancelled: BasicReferendumInfo
+  TimedOut: BasicReferendumInfo
   Killed: number
 }>
 

--- a/packages/sdk-governance/src/voting/sdk-types.ts
+++ b/packages/sdk-governance/src/voting/sdk-types.ts
@@ -1,4 +1,3 @@
-import { ReferendumInfo } from "@/referenda/descriptors"
 import { SS58String, Transaction } from "polkadot-api"
 import { Observable } from "rxjs"
 import { VotingConviction } from "./descriptors"
@@ -7,15 +6,6 @@ export type PollOutcome = {
   ended: number
   side: "aye" | "nay"
 } | null
-export const getReferendumOutcome = (referendum: ReferendumInfo) => {
-  if (referendum.type === "Approved" || referendum.type === "Rejected") {
-    return {
-      ended: referendum.value[0],
-      side: referendum.type === "Approved" ? "aye" : "nay",
-    }
-  }
-  return null
-}
 
 /**
  * Types:


### PR DESCRIPTION
When working on the conviction voting SDK, I realised that sometimes needs a "poll outcome", which is the result of a referendum.

I created a helper function to turn a "ReferendumInfo" from the typed api to a poll outcome, but It didn't feel right that the referenda SDK didn't have a direct connection with that.

I think it's then better to have the referenda SDK return all of the referendums on-chain. The ones that are not ongoing are also confusing to use, because it uses a tuple to store various information that actually has a meaning (block, submission deposit and decision deposit)