### PR TITLE
fix(ink): decode debug panic! and return_value messages (and other feedback)

### DIFF
--- a/examples/ink-playground/src/flipper.ts
+++ b/examples/ink-playground/src/flipper.ts
@@ -7,6 +7,8 @@ import { ADDRESS } from "./util/address"
 import { aliceSigner } from "./util/signer"
 import { trackTx } from "./util/trackTx"
 
+let CONTRACT_ADDRESS = ADDRESS.flipper
+
 const client = createClient(
   withPolkadotSdkCompat(
     getWsProvider([
@@ -27,6 +29,16 @@ const pvmBytes = Binary.fromBytes(await pvmFile.bytes())
 
 const deployer = flipperSdk.getDeployer(pvmBytes)
 
+// Example on how to get an estimated deployed address
+const estimatedAddress = await deployer.estimateAddress("new", {
+  data: {
+    initial_value: false,
+  },
+  origin: ADDRESS.alice,
+})
+console.log("estimated address", estimatedAddress)
+
+// Example on dry-running a contract deployment
 console.log("Dry-running deploy")
 const dryRunResult = await deployer.dryRun("new", {
   data: {
@@ -36,47 +48,38 @@ const dryRunResult = await deployer.dryRun("new", {
 })
 
 if (!dryRunResult.success) {
-  if (dryRunResult.value.value?.value?.type === "DuplicateContract") {
-    console.log("Dry run failed because duplicate contract (expected)")
-  } else {
-    console.log("Dry run did not succeed", dryRunResult.value)
-    process.exit(0)
-  }
-} else {
-  console.log("Dry-run success", {
-    address: dryRunResult.value.address,
-    // Expected to be different, because the address returned by the dry-run is bugged https://github.com/paritytech/contract-issues/issues/37
-    // so this estimatedAddress is better.
-    estimatedAddress: await deployer.estimateAddress("new", {
-      data: {
-        initial_value: false,
-      },
-      origin: ADDRESS.alice,
-    }),
-    events: dryRunResult.value.events,
-    storageDeposit: dryRunResult.value.storageDeposit,
-  })
+  console.log("Dry run did not succeed", dryRunResult.value)
+  process.exit(0)
+}
 
-  if (process.argv.includes("deploy")) {
-    console.log("Deploying...")
-    const fin = await trackTx(
-      dryRunResult.value.deploy().signSubmitAndWatch(aliceSigner),
-    )
-    console.log(`Deployed to address ${dryRunResult.value.address}`)
-    console.log(flipperSdk.readDeploymentEvents(fin.events))
-    // console.log(
-    //   JSON.stringify(fin.events, (_, v) =>
-    //     typeof v === "bigint"
-    //       ? String(v)
-    //       : v instanceof Binary
-    //         ? `bin${v.asHex()}`
-    //         : v,
-    //   ),
-    // )
+console.log("Dry-run success", {
+  address: dryRunResult.value.address,
+  events: dryRunResult.value.events,
+  storageDeposit: dryRunResult.value.storageDeposit,
+})
+
+if (process.argv.includes("deploy")) {
+  console.log("Deploying...")
+  // Note: we could also deploy directly without dry-run with `deployer.deploy`, but it would need the storageDeposit / weights.
+  const fin = await trackTx(
+    dryRunResult.value.deploy().signSubmitAndWatch(aliceSigner),
+  )
+
+  // After a long battle, we managed to get the `ContractInstantiated` event back https://github.com/paritytech/polkadot-sdk/issues/8677
+  // For chains with this deployed, we can get the address directly from the events
+  const events = flipperSdk.readDeploymentEvents(fin.events)
+  // It's an array because we can batch multiple deployments with one transaction.
+  if (events.length) {
+    console.log(`Deployed to address ${events[0].address}`)
+    CONTRACT_ADDRESS = events[0].address
+  } else {
+    // If the chain doesn't have the event deployed yet, then the best we can do is the dry-run estimate.
+    console.log(`Deployed to address ${dryRunResult.value.address} (maybe)`)
+    CONTRACT_ADDRESS = dryRunResult.value.address
   }
 }
 
-const contract = flipperSdk.getContract(ADDRESS.flipper)
+const contract = flipperSdk.getContract(CONTRACT_ADDRESS)
 console.log(`Deployed contract is compatible: ${await contract.isCompatible()}`)
 
 const contractAccount = await typedApi.query.System.Account.getValue(
@@ -110,6 +113,7 @@ console.log(`flip dry-run success`, {
 
 if (process.argv.includes("flip")) {
   console.log("flipping...")
+  // Note: we could also flip directly without dry-run with `contract.send`, but it would need the storageDeposit / weights.
   const fin = await trackTx(
     flipResult.value.send().signSubmitAndWatch(aliceSigner),
   )
@@ -123,11 +127,11 @@ if (process.argv.includes("flip")) {
 }
 
 // Storage not supported yet until get_storage_var_key is deployed
-// const rootStorage = await contract.getStorage().getRoot()
-// if (rootStorage.success) {
-//   console.log("flip storage", rootStorage.value)
-// } else {
-//   console.log("root storage query failed", rootStorage.value)
-// }
+const rootStorage = await contract.getStorage().getRoot()
+if (rootStorage.success) {
+  console.log("flip storage", rootStorage.value)
+} else {
+  console.log("root storage query failed", rootStorage.value)
+}
 
 client.destroy()

--- a/packages/sdk-ink/CHANGELOG.md
+++ b/packages/sdk-ink/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- `reviveAddressIsMapped()` standalone utility to have it without the need of specifiying a contract.
+
+### Fixed
+
+- `contract.query()` will decode debug `panic!()` and `return_value(REVERT, &"message")` messages as `{ success: false, value: { type: 'FlagReverted', value: { message, .. }}}`.
+
 ## 0.3.2 2025-07-16
 
 ### Fixed

--- a/packages/sdk-ink/package.json
+++ b/packages/sdk-ink/package.json
@@ -43,7 +43,8 @@
   "dependencies": {
     "@ethereumjs/rlp": "^10.0.0",
     "@noble/hashes": "^1.8.0",
-    "@polkadot-api/common-sdk-utils": "workspace:*"
+    "@polkadot-api/common-sdk-utils": "workspace:*",
+    "@polkadot-api/substrate-bindings": "^0.14.0"
   },
   "peerDependencies": {
     "@polkadot-api/ink-contracts": ">=0.3.4",

--- a/packages/sdk-ink/src/get-contract.ts
+++ b/packages/sdk-ink/src/get-contract.ts
@@ -4,6 +4,7 @@ import {
   wrapAsyncTx,
 } from "@polkadot-api/common-sdk-utils"
 import type { InkClient, InkMetadataLookup } from "@polkadot-api/ink-contracts"
+import { Binary, compactNumber } from "@polkadot-api/substrate-bindings"
 import { Enum, SS58String } from "polkadot-api"
 import type {
   GenericInkDescriptors,
@@ -72,23 +73,57 @@ export function getContract<
         data,
       )
       if (response.result.success) {
+        const availableData = {
+          events: inkClient.event.filter(mapAddr(address), response.events),
+          gasRequired: response.gas_required,
+          storageDeposit: getSignedStorage(response.storage_deposit),
+          send: () => {
+            const limitParams = {
+              gasLimit: response.gas_required,
+              storageDepositLimit: getStorageLimit(response.storage_deposit),
+            }
+            return contractApi.send(message, {
+              ...args,
+              ...limitParams,
+            })
+          },
+        }
+
+        // In case REVERT flag is set, it might return a string with the error message or debug info.
+        if (response.result.value.flags & 0x01) {
+          const data = response.result.value.data
+          // In case of panic! or return_value(REVERT, &"some message"), the value comes back as an opaque string
+          // Meaning what we get over the wire is [payload_len,data]
+          // And `data` is a Vec<u8>, hence [msg_len,...chars]. In this case, the msg_len is redundant.
+          const decodeMessage = () => {
+            try {
+              const bytes = data.asBytes()
+              const length = compactNumber.dec(bytes)
+              const compactLength = compactNumber.enc(length).length
+              if (compactLength + length === bytes.length) {
+                return Binary.fromBytes(bytes.slice(compactLength)).asText()
+              }
+            } catch {}
+            return data.asHex()
+          }
+          return {
+            success: false,
+            value: {
+              type: "FlagReverted",
+              value: {
+                ...availableData,
+                message: decodeMessage(),
+                raw: response.result.value.data,
+              },
+            },
+          }
+        }
+
         const decoded = msg.decode(response.result.value)
         return mapResult(flattenResult(decoded), {
           value: (innerResponse) => ({
             response: innerResponse,
-            events: inkClient.event.filter(mapAddr(address), response.events),
-            gasRequired: response.gas_required,
-            storageDeposit: getSignedStorage(response.storage_deposit),
-            send: () => {
-              const limitParams = {
-                gasLimit: response.gas_required,
-                storageDepositLimit: getStorageLimit(response.storage_deposit),
-              }
-              return contractApi.send(message, {
-                ...args,
-                ...limitParams,
-              })
-            },
+            ...availableData,
           }),
         })
       }

--- a/packages/sdk-ink/src/sdk-types.ts
+++ b/packages/sdk-ink/src/sdk-types.ts
@@ -21,6 +21,8 @@ import type {
   InkSdkApis,
   InkSdkPallets,
   InkSdkTypedApi,
+  ReviveSdkApis,
+  ReviveSdkPallets,
   ReviveSdkTypedApi,
 } from "./descriptor-types"
 import type { SdkStorage } from "./get-storage"
@@ -122,7 +124,11 @@ export interface Deployer<
 type GetErr<T> =
   T extends TypedApi<SdkDefinition<InkSdkPallets, InkSdkApis<any, infer R>>>
     ? R
-    : any
+    : T extends TypedApi<
+          SdkDefinition<ReviveSdkPallets, ReviveSdkApis<any, infer R>>
+        >
+      ? R
+      : any
 
 export type StorageRootType<T extends InkStorageDescriptor> = "" extends keyof T
   ? T[""]["value"]
@@ -149,7 +155,18 @@ export interface Contract<
         storageDeposit: bigint
         send: () => AsyncTransaction<any, any, any, any>
       },
-      GetErr<T> | FlattenErrors<D["__types"]["messages"][L]["response"]>
+      | GetErr<T>
+      | FlattenErrors<D["__types"]["messages"][L]["response"]>
+      | {
+          type: "FlagReverted"
+          value: {
+            message: string
+            raw: Binary
+            gasRequired: Gas
+            storageDeposit: bigint
+            send: () => AsyncTransaction<any, any, any, any>
+          }
+        }
     >
   >
   send: <L extends string & keyof D["__types"]["messages"]>(

--- a/packages/sdk-ink/src/util.ts
+++ b/packages/sdk-ink/src/util.ts
@@ -9,7 +9,7 @@ import {
   SS58String,
 } from "polkadot-api"
 import { mergeUint8 } from "polkadot-api/utils"
-import { ReviveAddress, U256 } from "./descriptor-types"
+import { ReviveAddress, ReviveSdkTypedApi, U256 } from "./descriptor-types"
 
 export const getSignedStorage = (
   depositResponse: Enum<{
@@ -30,6 +30,14 @@ export const getStorageLimit = (
 
 export const ss58ToEthereum = (address: SS58String): Binary =>
   Binary.fromBytes(keccak_256(AccountId().enc(address)).slice(12))
+
+export const reviveAddressIsMapped = (
+  typedApi: ReviveSdkTypedApi,
+  address: SS58String,
+) =>
+  typedApi.query.Revive.OriginalAccount.getValue(ss58ToEthereum(address)).then(
+    (r) => r != null,
+  )
 
 const u64Range = 2n ** 64n
 export const valueToU256 = (value: bigint): U256 => [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       '@polkadot-api/common-sdk-utils':
         specifier: workspace:*
         version: link:../common-utils
+      '@polkadot-api/substrate-bindings':
+        specifier: ^0.14.0
+        version: 0.14.0
     devDependencies:
       '@polkadot-api/ink-contracts':
         specifier: ^0.3.4


### PR DESCRIPTION
We got very valuable feedback when working with others on the web3 summit "The Blockspace" hackathon.

This PR addresses some pain points and updates the ink!v6 example to clarify a few points.

One we found is the "feature" where ink! will return as a contract response a text message in debug mode, in case the contract panics. This is way more useful when debugging contracts rather than getting a "ContractTrapped" or "ContractReverted" event.

But the ink-sdk was not handling this correctly. Now it will return a `success: false` result with type `FlagReverted` with the message decoded back into a string for easier debugging experience™.